### PR TITLE
feat: multiexample sections

### DIFF
--- a/src/registry/utils/interfaces.ts
+++ b/src/registry/utils/interfaces.ts
@@ -1,4 +1,4 @@
-import { Node } from 'unist';
+import type { Node } from 'unist';
 
 export type HtmlNode = Node & {
   type: string;


### PR DESCRIPTION
Приклад вмісту, в якому необхідна ця можливість: https://github.com/webdoky/content/blob/1f20d00953bc07c0f708247b5c7ef171301bdb42/files/uk/web/css/using_css_custom_properties/index.md?plain=1#L268
Проблемна сторінка: https://webdoky.org/uk/docs/Web/CSS/Using_CSS_custom_properties/
Можливість у дії:
<img width="722" alt="Screenshot 2024-01-29 at 11 44 51" src="https://github.com/webdoky/content-processor/assets/22787669/aa76fb5e-c090-4326-bd56-2ccc51715dbd">
